### PR TITLE
Drop support for python 3.9 and below

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -64,5 +64,5 @@ jobs:
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
             echo '::set-output name=matrix::["3.12"]'
           else
-            echo '::set-output name=matrix::["3.8", "3.9", "3.10", "3.11", "3.12"]'
+            echo '::set-output name=matrix::["3.10", "3.11", "3.12"]'
           fi

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 # Herculens: differentiable gravitational lensing
 
-![PyPi python support](https://img.shields.io/badge/Python-3.9%20%7C%203.12-blue)
+![PyPi python support](https://img.shields.io/badge/Python-3.10%20%7C%203.12-blue)
 [![Tests](https://github.com/austinpeel/herculens/actions/workflows/ci_tests.yml/badge.svg?branch=main)](https://github.com/austinpeel/herculens/actions/workflows/ci_tests.yml)
 [![arXiv](https://img.shields.io/badge/arXiv-2207.05763-b31b1b.svg)](https://arxiv.org/abs/2207.05763)
 ![License](https://img.shields.io/github/license/austinpeel/herculens)

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ with open(os.path.join(this_directory, 'README.md'), encoding='utf-8') as f:
 long_description = readme.replace('<img src="https://raw.githubusercontent.com/Herculens/herculens/main/images/horizontal_dark_bg.png#gh-dark-mode-only" width="600" alt="Herculens logo" />', '')
 
 # Python version
-python_requires = '>=3.9'
+python_requires = '>=3.10'
 
 # Minimal required packages (see requirements.txt for versions)
 install_requires = [


### PR DESCRIPTION
In particular, this is for consistency with requirements such as `jax>=0.5.0` and `nifty8>=8.5.7`.