### PR TITLE
Use vmap for repeated mass profiles

### DIFF
--- a/herculens/MassModel/mass_model.py
+++ b/herculens/MassModel/mass_model.py
@@ -22,7 +22,7 @@ __all__ = ['MassModel', 'ZeroMassModel']
 
 
 def tree_stack(trees):
-    return jax.tree_map(lambda *v: jnp.stack(v), *trees)
+    return jax.tree.map(lambda *v: jnp.stack(v), *trees)
 
 
 def alpha_static_single(


### PR DESCRIPTION
This change avoids long compile times by removing the `for` loop from the code and replacing it with a `vmap` over the stacked inputs of the function.

In local testing with a model with 125 components, this brought down the compile time for `ray_shooting` from about 40 seconds to 1 second.  The initialization for a Numpyro model went down from 6 minutes to 30 seconds.

There might be scope to use `vmap` to also account for `alpha_static_single` at the same time, but this might be more hassle than it is worth, as I think you would need to know how many keyword arguments each mass profile has before doing the `vmap`.