### PR TITLE
Declare jax_cosmo in install_requires (required by MPMassModel)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ install_requires = [
     'objax>=1.8.0',
     'scikit-image>=0.20.0',
     'utax>=0.0.2',
+    'jax_cosmo @ git+https://github.com/martin-millon/jax_cosmo.git', # as soon as this fork gets merged, change to jax-cosmo only
 ]
 
 # Minimal optional packages (see also requirements.txt for even more optional packages)


### PR DESCRIPTION
herculens/__init__.py imports now MPMassModel, which in turn does `import jax_cosmo as jc` at top of
herculens/MassModel/mass_model_multiplane.py. However, jax_cosmo is only listed in test_requirements.txt (added in commit "adding jax_cosmo as test requirements"), which pip never reads when downstream packages install herculens.

As a result, a fresh `pip install git+https://github.com/Herculens/herculens.git` into a clean Python venv produces a herculens that immediately fails on `import herculens` with `ModuleNotFoundError: No module named 'jax_cosmo'`. We want to stick to the fork of @martin-millon which removes the dependencies to setuptool.