### PR TITLE
Fix adaptive pixelated grid for bilinear interpolation

### DIFF
--- a/herculens/LightModel/Profiles/pixelated.py
+++ b/herculens/LightModel/Profiles/pixelated.py
@@ -124,6 +124,8 @@ class Pixelated(object):
         # setup interpolation, assuming cartesian grid
         if not self._adaptive_grid:  # in this case pixels_x_coord and pixels_y_coord should be None
             pixels_x_coord, pixels_y_coord = self._x_coords, self._y_coords
+        else:  # in this case pixels_x_coord and pixels_y_coord should be converted to pixel units as well
+            pixels_x_coord, pixels_y_coord = self.pixel_grid.map_coord2pix(pixels_x_coord, pixels_y_coord)
         interp = self._interp_class(pixels_y_coord, pixels_x_coord, pixels,
                                     allow_extrapolation=self._extrapol_bool)
         # evaluate the interpolator

--- a/herculens/LightModel/Profiles/pixelated.py
+++ b/herculens/LightModel/Profiles/pixelated.py
@@ -166,6 +166,8 @@ class Pixelated(object):
         # setup interpolation, assuming cartesian grid
         if not self._adaptive_grid:  # in this case pixels_x_coord and pixels_y_coord should be None
             pixels_x_coord, pixels_y_coord = self._x_coords, self._y_coords
+        else:  # in this case pixels_x_coord and pixels_y_coord should be converted to pixel units as well
+            pixels_x_coord, pixels_y_coord = self.pixel_grid.map_coord2pix(pixels_x_coord, pixels_y_coord)
         interp = interp_class(pixels_y_coord, pixels_x_coord, pixels,
                               allow_extrapolation=self._extrapol_bool)
         # evaluate the interpolator


### PR DESCRIPTION
Fixes #93

Internally the `Pixelated` class converts all angular units to pixel units before interpolation.  In the case of the adaptive grid the input `pixels_x_coord` and `pixels_y_coord` also need to be converted.  This is done inside the `_function_fast` but was not done inside `_function_std`.  This meant that things would work as expected if `interpolation_type='fast_bilinear'` but not if `interpolation_type='bilinear'`.

This can cause further issues as the `jaxinterp2d` package needs to be installed by the user before `fast_bilinear` can be used otherwise it will fallback to `bilinear`.  While the code does produce a warning message when this fallback happens, this gets swallowed by Jax if called by a `jit`ed function.  So the most common case of a `lens_image.model` call does not show this warning.

This PR ensures that the pixel bin centers and the interpolation positions are in the same units before interpolation in the `_function_std` class method.  Now both `fast_bilinear` and `bilinear` produce the same results when an adaptive grid is used.